### PR TITLE
Fix structured task cancellation propagation

### DIFF
--- a/PipeEx.StructuredConcurrency/StructuredConcurrency.cs
+++ b/PipeEx.StructuredConcurrency/StructuredConcurrency.cs
@@ -62,6 +62,11 @@ public static class StructuredConcurrency
 
                 tcs.SetResult(result);
             }
+            catch (OperationCanceledException oce)
+            {
+                cts.Cancel();
+                tcs.TrySetCanceled(oce.CancellationToken);
+            }
             catch (Exception ex)
             {
                 cts.Cancel();
@@ -110,6 +115,11 @@ public static class StructuredConcurrency
                 var result = await innerStructuredTask.ConfigureAwait(false);
 
                 tcs.SetResult(result);
+            }
+            catch (OperationCanceledException oce)
+            {
+                cts.Cancel();
+                tcs.TrySetCanceled(oce.CancellationToken);
             }
             catch (Exception ex)
             {

--- a/PipeEx.StructuredConcurrency/StructuredConcurrency.cs
+++ b/PipeEx.StructuredConcurrency/StructuredConcurrency.cs
@@ -52,7 +52,7 @@ public static class StructuredConcurrency
                 if (source.IsCanceled)
                 {
                     cts.Cancel();
-                    tcs.SetException(new OperationCanceledException());
+                    tcs.SetCanceled(cts.Token);
                     return;
                 }
                 var innerStructuredTask = func(await source.ConfigureAwait(false));
@@ -101,7 +101,7 @@ public static class StructuredConcurrency
                 if (source.Task.IsCanceled)
                 {
                     cts.Cancel();
-                    tcs.SetException(new OperationCanceledException());
+                    tcs.SetCanceled(cts.Token);
                     return;
                 }
 

--- a/PipeEx.Tests/StructuredConcurrencyTests.cs
+++ b/PipeEx.Tests/StructuredConcurrencyTests.cs
@@ -148,6 +148,30 @@ public class StructuredConcurrencyTests
             Assert.Equal("boom", ex.Message);
         });
 
+    [Fact]
+    public Task Test11_TaskSourceToStructuredTaskFunc_SourceCancellation_CompletesAsCanceledTask() =>
+        Arrange(() => new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously))
+        .Act(x =>
+        {
+            var structuredTask = x.Task.I(StructuredDouble);
+
+            x.SetCanceled();
+            return structuredTask;
+        })
+        .Assert(async structuredTask => await Assert.ThrowsAsync<TaskCanceledException>(async () => await structuredTask));
+
+    [Fact]
+    public Task Test12_StructuredTaskToStructuredTaskFunc_SourceCancellation_CompletesAsCanceledTask() =>
+        Arrange(() => new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously))
+        .Act(x =>
+        {
+            var structuredTask = x.Task.I(val => Task.FromResult(val * 2)).I(StructuredDouble);
+
+            x.SetCanceled();
+            return structuredTask;
+        })
+        .Assert(async structuredTask => await Assert.ThrowsAsync<TaskCanceledException>(async () => await structuredTask));
+
     private static StructuredTask<int> StructuredDouble(int v) => v.I<int, int>(w => Task.FromResult(w * 2));
 
     private static StructuredTask<int> StructuredThrow(int v) =>

--- a/PipeEx.Tests/StructuredConcurrencyTests.cs
+++ b/PipeEx.Tests/StructuredConcurrencyTests.cs
@@ -148,8 +148,45 @@ public class StructuredConcurrencyTests
             Assert.Equal("boom", ex.Message);
         });
 
+    // The wrapper overloads (Task -> StructuredTask and StructuredTask -> StructuredTask) observe source
+    // cancellation through two distinct paths: the synchronous "already canceled" check at the top of the
+    // worker (exercised when the source is canceled BEFORE chaining, Test11/Test12) and the catch block
+    // when the awaited source cancels LATER (Test13/Test14). Both paths must complete the wrapper as a
+    // canceled task rather than a faulted one, so each test also asserts IsCanceled (awaiting alone cannot
+    // distinguish a Canceled task from one faulted with a TaskCanceledException).
+
     [Fact]
-    public Task Test11_TaskSourceToStructuredTaskFunc_SourceCancellation_CompletesAsCanceledTask() =>
+    public Task Test11_TaskSourceToStructuredTaskFunc_SourceCanceledBeforeChaining_CompletesAsCanceledTask() =>
+        Arrange(() =>
+        {
+            var source = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            source.SetCanceled();
+            return source;
+        })
+        .Act(x => x.Task.I(StructuredDouble))
+        .Assert(async structuredTask =>
+        {
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await structuredTask);
+            Assert.True(((Task<int>)structuredTask).IsCanceled);
+        });
+
+    [Fact]
+    public Task Test12_StructuredTaskToStructuredTaskFunc_SourceCanceledBeforeChaining_CompletesAsCanceledTask() =>
+        Arrange(() =>
+        {
+            var source = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            source.SetCanceled();
+            return source;
+        })
+        .Act(x => x.Task.I(val => Task.FromResult(val * 2)).I(StructuredDouble))
+        .Assert(async structuredTask =>
+        {
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await structuredTask);
+            Assert.True(((Task<int>)structuredTask).IsCanceled);
+        });
+
+    [Fact]
+    public Task Test13_TaskSourceToStructuredTaskFunc_SourceCanceledWhileAwaiting_CompletesAsCanceledTask() =>
         Arrange(() => new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously))
         .Act(x =>
         {
@@ -158,10 +195,14 @@ public class StructuredConcurrencyTests
             x.SetCanceled();
             return structuredTask;
         })
-        .Assert(async structuredTask => await Assert.ThrowsAsync<TaskCanceledException>(async () => await structuredTask));
+        .Assert(async structuredTask =>
+        {
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await structuredTask);
+            Assert.True(((Task<int>)structuredTask).IsCanceled);
+        });
 
     [Fact]
-    public Task Test12_StructuredTaskToStructuredTaskFunc_SourceCancellation_CompletesAsCanceledTask() =>
+    public Task Test14_StructuredTaskToStructuredTaskFunc_SourceCanceledWhileAwaiting_CompletesAsCanceledTask() =>
         Arrange(() => new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously))
         .Act(x =>
         {
@@ -170,7 +211,11 @@ public class StructuredConcurrencyTests
             x.SetCanceled();
             return structuredTask;
         })
-        .Assert(async structuredTask => await Assert.ThrowsAsync<TaskCanceledException>(async () => await structuredTask));
+        .Assert(async structuredTask =>
+        {
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await structuredTask);
+            Assert.True(((Task<int>)structuredTask).IsCanceled);
+        });
 
     private static StructuredTask<int> StructuredDouble(int v) => v.I<int, int>(w => Task.FromResult(w * 2));
 


### PR DESCRIPTION
### Motivation
- Ensure wrapper structured tasks observe and propagate cancellation when their source `Task` is already canceled so awaiting the wrapper yields a `TaskCanceledException` rather than a faulted `Task`.
- Add regression coverage for the Task->StructuredTask and StructuredTask->StructuredTask chaining paths to prevent future regressions.

### Description
- In `PipeEx.StructuredConcurrency/StructuredConcurrency.cs` replace `tcs.SetException(new OperationCanceledException())` with `tcs.SetCanceled(cts.Token)` in both `Task<TSource>.I(Func<TSource, StructuredTask<TResult>>)` and `StructuredTask<TSource>.I(Func<TSource, StructuredTask<TResult>>)` code paths to mark the wrapper as canceled instead of faulted.
- Preserve the existing `cts.Cancel()` behavior so the linked cancellation token hierarchy remains correct when the source is canceled.
- Add two unit tests to `PipeEx.Tests/StructuredConcurrencyTests.cs`: `Test11_TaskSourceToStructuredTaskFunc_SourceCancellation_CompletesAsCanceledTask` and `Test12_StructuredTaskToStructuredTaskFunc_SourceCancellation_CompletesAsCanceledTask`, which assert that awaiting the wrapper throws `TaskCanceledException` when the source `TaskCompletionSource` is canceled.

### Testing
- Added unit tests in `PipeEx.Tests/StructuredConcurrencyTests.cs` but `dotnet test PipeEx.sln` could not be executed in this environment because `dotnet` is not installed, so the new tests were not run here.
- Recommend running `dotnet test PipeEx.sln` in a .NET-enabled environment or CI to validate the new tests (they are expected to pass once executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3062a2e9188323a462fc258dbfaaef)