### PR TITLE
Simplify: extract shared tuple→StructuredTask helper (−1241 lines, no API change)

### DIFF
--- a/PipeEx.StructuredConcurrency/StructuredConcurrency.TupleDestructuring.g.cs
+++ b/PipeEx.StructuredConcurrency/StructuredConcurrency.TupleDestructuring.g.cs
@@ -49,111 +49,11 @@ public static class TupleDestructuring
         return new StructuredTask<TResult>(impl(), s);
     }
 
-     public static StructuredTask<TResult> I<TSource1, TSource2, TResult>(this Task<(TSource1, TSource2)> s, Func<TSource1, TSource2, StructuredTask<TResult>> func)
-    {
-        var cts = new CancellationTokenSource();
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+    public static StructuredTask<TResult> I<TSource1, TSource2, TResult>(this Task<(TSource1, TSource2)> s, Func<TSource1, TSource2, StructuredTask<TResult>> func)
+        => StructuredConcurrency.ChainTupleToStructured(s, t => func(t.Item1, t.Item2), new CancellationTokenSource());
 
     public static StructuredTask<TResult> I<TSource1, TSource2, TResult>(this StructuredTask<(TSource1, TSource2)> s, Func<TSource1, TSource2, StructuredTask<TResult>> func)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token);
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+        => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func(t.Item1, t.Item2), CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
 
     public static async StructuredTask<TResult> I<TSource1, TSource2, TSource3, TResult>(this (TSource1, TSource2, TSource3) source, Func<TSource1, TSource2, TSource3, Task<TResult>> func)
     {
@@ -201,111 +101,11 @@ public static class TupleDestructuring
         return new StructuredTask<TResult>(impl(), s);
     }
 
-     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TResult>(this Task<(TSource1, TSource2, TSource3)> s, Func<TSource1, TSource2, TSource3, StructuredTask<TResult>> func)
-    {
-        var cts = new CancellationTokenSource();
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+    public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TResult>(this Task<(TSource1, TSource2, TSource3)> s, Func<TSource1, TSource2, TSource3, StructuredTask<TResult>> func)
+        => StructuredConcurrency.ChainTupleToStructured(s, t => func(t.Item1, t.Item2, t.Item3), new CancellationTokenSource());
 
     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TResult>(this StructuredTask<(TSource1, TSource2, TSource3)> s, Func<TSource1, TSource2, TSource3, StructuredTask<TResult>> func)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token);
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+        => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func(t.Item1, t.Item2, t.Item3), CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
 
     public static async StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TResult>(this (TSource1, TSource2, TSource3, TSource4) source, Func<TSource1, TSource2, TSource3, TSource4, Task<TResult>> func)
     {
@@ -353,111 +153,11 @@ public static class TupleDestructuring
         return new StructuredTask<TResult>(impl(), s);
     }
 
-     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4)> s, Func<TSource1, TSource2, TSource3, TSource4, StructuredTask<TResult>> func)
-    {
-        var cts = new CancellationTokenSource();
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+    public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4)> s, Func<TSource1, TSource2, TSource3, TSource4, StructuredTask<TResult>> func)
+        => StructuredConcurrency.ChainTupleToStructured(s, t => func(t.Item1, t.Item2, t.Item3, t.Item4), new CancellationTokenSource());
 
     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TResult>(this StructuredTask<(TSource1, TSource2, TSource3, TSource4)> s, Func<TSource1, TSource2, TSource3, TSource4, StructuredTask<TResult>> func)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token);
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+        => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func(t.Item1, t.Item2, t.Item3, t.Item4), CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
 
     public static async StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TResult>(this (TSource1, TSource2, TSource3, TSource4, TSource5) source, Func<TSource1, TSource2, TSource3, TSource4, TSource5, Task<TResult>> func)
     {
@@ -505,111 +205,11 @@ public static class TupleDestructuring
         return new StructuredTask<TResult>(impl(), s);
     }
 
-     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, StructuredTask<TResult>> func)
-    {
-        var cts = new CancellationTokenSource();
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+    public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, StructuredTask<TResult>> func)
+        => StructuredConcurrency.ChainTupleToStructured(s, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5), new CancellationTokenSource());
 
     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TResult>(this StructuredTask<(TSource1, TSource2, TSource3, TSource4, TSource5)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, StructuredTask<TResult>> func)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token);
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+        => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5), CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
 
     public static async StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TResult>(this (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6) source, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, Task<TResult>> func)
     {
@@ -657,111 +257,11 @@ public static class TupleDestructuring
         return new StructuredTask<TResult>(impl(), s);
     }
 
-     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, StructuredTask<TResult>> func)
-    {
-        var cts = new CancellationTokenSource();
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+    public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, StructuredTask<TResult>> func)
+        => StructuredConcurrency.ChainTupleToStructured(s, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6), new CancellationTokenSource());
 
     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TResult>(this StructuredTask<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, StructuredTask<TResult>> func)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token);
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+        => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6), CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
 
     public static async StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TResult>(this (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7) source, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, Task<TResult>> func)
     {
@@ -809,111 +309,11 @@ public static class TupleDestructuring
         return new StructuredTask<TResult>(impl(), s);
     }
 
-     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, StructuredTask<TResult>> func)
-    {
-        var cts = new CancellationTokenSource();
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+    public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, StructuredTask<TResult>> func)
+        => StructuredConcurrency.ChainTupleToStructured(s, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7), new CancellationTokenSource());
 
     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TResult>(this StructuredTask<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, StructuredTask<TResult>> func)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token);
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+        => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7), CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
 
     public static async StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TResult>(this (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8) source, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, Task<TResult>> func)
     {
@@ -961,111 +361,11 @@ public static class TupleDestructuring
         return new StructuredTask<TResult>(impl(), s);
     }
 
-     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, StructuredTask<TResult>> func)
-    {
-        var cts = new CancellationTokenSource();
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7, source.Item8);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+    public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, StructuredTask<TResult>> func)
+        => StructuredConcurrency.ChainTupleToStructured(s, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7, t.Item8), new CancellationTokenSource());
 
     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TResult>(this StructuredTask<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, StructuredTask<TResult>> func)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token);
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7, source.Item8);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+        => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7, t.Item8), CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
 
     public static async StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TResult>(this (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9) source, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, Task<TResult>> func)
     {
@@ -1113,111 +413,11 @@ public static class TupleDestructuring
         return new StructuredTask<TResult>(impl(), s);
     }
 
-     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, StructuredTask<TResult>> func)
-    {
-        var cts = new CancellationTokenSource();
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7, source.Item8, source.Item9);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+    public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, StructuredTask<TResult>> func)
+        => StructuredConcurrency.ChainTupleToStructured(s, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7, t.Item8, t.Item9), new CancellationTokenSource());
 
     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TResult>(this StructuredTask<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, StructuredTask<TResult>> func)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token);
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7, source.Item8, source.Item9);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+        => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7, t.Item8, t.Item9), CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
 
     public static async StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TResult>(this (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10) source, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, Task<TResult>> func)
     {
@@ -1265,111 +465,11 @@ public static class TupleDestructuring
         return new StructuredTask<TResult>(impl(), s);
     }
 
-     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, StructuredTask<TResult>> func)
-    {
-        var cts = new CancellationTokenSource();
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7, source.Item8, source.Item9, source.Item10);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+    public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, StructuredTask<TResult>> func)
+        => StructuredConcurrency.ChainTupleToStructured(s, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7, t.Item8, t.Item9, t.Item10), new CancellationTokenSource());
 
     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TResult>(this StructuredTask<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, StructuredTask<TResult>> func)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token);
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7, source.Item8, source.Item9, source.Item10);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+        => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7, t.Item8, t.Item9, t.Item10), CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
 
     public static async StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TResult>(this (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11) source, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, Task<TResult>> func)
     {
@@ -1417,111 +517,11 @@ public static class TupleDestructuring
         return new StructuredTask<TResult>(impl(), s);
     }
 
-     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, StructuredTask<TResult>> func)
-    {
-        var cts = new CancellationTokenSource();
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7, source.Item8, source.Item9, source.Item10, source.Item11);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+    public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, StructuredTask<TResult>> func)
+        => StructuredConcurrency.ChainTupleToStructured(s, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7, t.Item8, t.Item9, t.Item10, t.Item11), new CancellationTokenSource());
 
     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TResult>(this StructuredTask<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, StructuredTask<TResult>> func)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token);
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7, source.Item8, source.Item9, source.Item10, source.Item11);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+        => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7, t.Item8, t.Item9, t.Item10, t.Item11), CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
 
     public static async StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TResult>(this (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12) source, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, Task<TResult>> func)
     {
@@ -1569,111 +569,11 @@ public static class TupleDestructuring
         return new StructuredTask<TResult>(impl(), s);
     }
 
-     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, StructuredTask<TResult>> func)
-    {
-        var cts = new CancellationTokenSource();
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7, source.Item8, source.Item9, source.Item10, source.Item11, source.Item12);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+    public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, StructuredTask<TResult>> func)
+        => StructuredConcurrency.ChainTupleToStructured(s, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7, t.Item8, t.Item9, t.Item10, t.Item11, t.Item12), new CancellationTokenSource());
 
     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TResult>(this StructuredTask<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, StructuredTask<TResult>> func)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token);
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7, source.Item8, source.Item9, source.Item10, source.Item11, source.Item12);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+        => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7, t.Item8, t.Item9, t.Item10, t.Item11, t.Item12), CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
 
     public static async StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TResult>(this (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13) source, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, Task<TResult>> func)
     {
@@ -1721,109 +621,9 @@ public static class TupleDestructuring
         return new StructuredTask<TResult>(impl(), s);
     }
 
-     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, StructuredTask<TResult>> func)
-    {
-        var cts = new CancellationTokenSource();
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7, source.Item8, source.Item9, source.Item10, source.Item11, source.Item12, source.Item13);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+    public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TResult>(this Task<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, StructuredTask<TResult>> func)
+        => StructuredConcurrency.ChainTupleToStructured(s, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7, t.Item8, t.Item9, t.Item10, t.Item11, t.Item12, t.Item13), new CancellationTokenSource());
 
     public static StructuredTask<TResult> I<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TResult>(this StructuredTask<(TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13)> s, Func<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, StructuredTask<TResult>> func)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token);
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                (TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func(source.Item1, source.Item2, source.Item3, source.Item4, source.Item5, source.Item6, source.Item7, source.Item8, source.Item9, source.Item10, source.Item11, source.Item12, source.Item13);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+        => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5, t.Item6, t.Item7, t.Item8, t.Item9, t.Item10, t.Item11, t.Item12, t.Item13), CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
 }

--- a/PipeEx.StructuredConcurrency/StructuredConcurrency.TupleDestructuring.sh
+++ b/PipeEx.StructuredConcurrency/StructuredConcurrency.TupleDestructuring.sh
@@ -10,10 +10,12 @@ EOF
 for item in $(seq 1 12); do
     ty="TSource1"
     tv="source.Item1"
+    targ="t.Item1"
 
     for i in $(seq 1 $item); do
         ty="${ty}, TSource$((i + 1))"
         tv="${tv}, source.Item$((i + 1))"
+        targ="${targ}, t.Item$((i + 1))"
     done
 
 cat << EOF >> $fileName
@@ -64,111 +66,11 @@ cat << EOF >> $fileName
         return new StructuredTask<TResult>(impl(), s);
     }
 
-     public static StructuredTask<TResult> I<$ty, TResult>(this Task<($ty)> s, Func<$ty, StructuredTask<TResult>> func)
-    {
-        var cts = new CancellationTokenSource();
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                ($ty) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func($tv);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+    public static StructuredTask<TResult> I<$ty, TResult>(this Task<($ty)> s, Func<$ty, StructuredTask<TResult>> func)
+        => StructuredConcurrency.ChainTupleToStructured(s, t => func($targ), new CancellationTokenSource());
 
     public static StructuredTask<TResult> I<$ty, TResult>(this StructuredTask<($ty)> s, Func<$ty, StructuredTask<TResult>> func)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token);
-        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var impl = async () =>
-        {
-            try
-            {
-                ($ty) source;
-                try
-                {
-                    source = await s.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    cts.Cancel();
-                    tcs.SetCanceled(cts.Token);
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    return;
-                }
-
-                var innerStructuredTask = func($tv);
-
-                try
-                {
-                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
-                    var result = await innerStructuredTask.ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        };
-        impl();
-
-        return new StructuredTask<TResult>(tcs.Task, cts);
-    }
+        => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func($targ), CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
 EOF
 
 done

--- a/PipeEx.StructuredConcurrency/StructuredConcurrency.cs
+++ b/PipeEx.StructuredConcurrency/StructuredConcurrency.cs
@@ -131,7 +131,64 @@ public static class StructuredConcurrency
         return new StructuredTask<TResult>(tcs.Task, cts);
     }
 
-    public static StructuredDeferredTask<TSource, TDeferred> Let<TSource, TDeferred>(this TSource source, Func<Task<TDeferred>> func) => 
+    /// <summary>
+    /// Shared implementation for the generated tuple <c>... -&gt; StructuredTask</c> overloads: awaits
+    /// <paramref name="source"/>, invokes <paramref name="func"/> to get the inner StructuredTask, links
+    /// cancellation through <paramref name="cts"/>, and surfaces its result, cancellation or fault.
+    /// </summary>
+    internal static StructuredTask<TResult> ChainTupleToStructured<TTuple, TResult>(Task<TTuple> source, Func<TTuple, StructuredTask<TResult>> func, CancellationTokenSource cts)
+    {
+        var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var impl = async () =>
+        {
+            try
+            {
+                TTuple value;
+                try
+                {
+                    value = await source.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    cts.Cancel();
+                    tcs.SetCanceled(cts.Token);
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                    return;
+                }
+
+                var innerStructuredTask = func(value);
+
+                try
+                {
+                    using var innerRegistration = cts.Token.Register(() => innerStructuredTask.CancellationTokenSource.Cancel());
+                    var result = await innerStructuredTask.ConfigureAwait(false);
+                    tcs.SetResult(result);
+                }
+                catch (OperationCanceledException)
+                {
+                    tcs.SetCanceled(innerStructuredTask.CancellationTokenSource.Token);
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            }
+            catch (Exception ex)
+            {
+                tcs.TrySetException(ex);
+            }
+        };
+        impl();
+
+        return new StructuredTask<TResult>(tcs.Task, cts);
+    }
+
+    public static StructuredDeferredTask<TSource, TDeferred> Let<TSource, TDeferred>(this TSource source, Func<Task<TDeferred>> func) =>
         new StructuredDeferredTask<TSource, TDeferred>(Task.FromResult(source), func());
 
     public static StructuredDeferredTask<TSource, TDeferred> Let<TSource, TDeferred>(this TSource source, Func<TSource, Task<TDeferred>> func) => 


### PR DESCRIPTION
**Reworked per review.** The earlier arity-cap + `Let`-removal approach is reverted — arities **2–13** and the `Let(this TSource, Func<TSource, StructuredDeferredTask<…>>)` overload are back exactly as before. Per your steer, this now goes hard on something with **zero API impact**.

### What changed
The generated tuple-destructuring overloads that return a `StructuredTask` (the two `… → StructuredTask` shapes per arity) each inlined ~45 lines of identical `CancellationTokenSource`/`TaskCompletionSource` plumbing, repeated across arities 2–13 — ~1,000 lines of duplication.

Extracted that body **once** into an `internal StructuredConcurrency.ChainTupleToStructured<TTuple, TResult>(…)` helper; the generator now emits one-line delegations:

```csharp
public static StructuredTask<TResult> I<T1,T2,TResult>(this StructuredTask<(T1,T2)> s, Func<T1,T2,StructuredTask<TResult>> func)
    => StructuredConcurrency.ChainTupleToStructured(s.Task, t => func(t.Item1, t.Item2),
           CancellationTokenSource.CreateLinkedTokenSource(s.CancellationTokenSource.Token));
```

### Guarantees
- **No public API change** — all **96** tuple overloads keep their exact signatures; arity 2–13 intact; the helper is `internal`.
- **Behavior-preserving** — the helper is a byte-faithful copy of the previously inlined body, so cancellation/fault handling is unchanged. (`TrySetException` now appears once, in the helper, and zero times in the generated file — confirming the 24 per-method bodies were fully replaced.)
- `StructuredConcurrency.TupleDestructuring.g.cs`: **1877 → 629 lines** (−1248). Net diff **−1241**.

> Why not collapse it further (e.g. delegate straight to the non-tuple `.I`)? That hits a genuine overload-resolution ambiguity (`Func<T,TResult>` with `TResult = StructuredTask<…>` vs the explicit `StructuredTask` overload resolve to the same delegate type) — a uniquely-named helper sidesteps it. The non-tuple `… → StructuredTask` overloads use a *different* cancellation pattern (an early `IsCanceled` check), so they're intentionally left untouched to avoid any behavior change.

As before, I can't build locally — opening to CI for verification across the OS matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsqPxHuJp8KckiU4FE5hHk